### PR TITLE
Allow max RAM to be specified as a percentage of physical RAM etc

### DIFF
--- a/appbundler/src/com/oracle/appbundler/AppBundlerTask.java
+++ b/appbundler/src/com/oracle/appbundler/AppBundlerTask.java
@@ -40,9 +40,7 @@ import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -77,7 +75,7 @@ public class AppBundlerTask extends Task {
     private String copyright = "";
     private String privileged = null;
     private String workingDirectory = null;
-    private String minimumSystemVersion = null;
+    private String minimumSystemVersion = "10.7";
 
     private String jvmRequired = null;
     private boolean jrePreferred = false;
@@ -523,18 +521,19 @@ public class AppBundlerTask extends Task {
     }
 
     private void copyClassPathRefEntries(File javaDirectory) throws IOException {
-        if(classPathRef != null) {
-            org.apache.tools.ant.types.Path classpath =
-
-                    (org.apache.tools.ant.types.Path) classPathRef.getReferencedObject(getProject());
-
-            Iterator<FileResource> iter = (Iterator<FileResource>)(Object)classpath.iterator();
-            while(iter.hasNext()) {
-                FileResource resource = iter.next();
-                File source = resource.getFile();
-                File destination = new File(javaDirectory, source.getName());
-                copy(source, destination);
+        if (classPathRef != null) {
+          org.apache.tools.ant.types.Path classpath =
+            (org.apache.tools.ant.types.Path) classPathRef.getReferencedObject(getProject());
+          Iterator iter = classpath.iterator();
+          while (iter.hasNext()) {
+            Object resource = iter.next();
+            if (resource instanceof FileResource) {
+              FileResource fileResource = (FileResource) resource;
+              File source = fileResource.getFile();
+              File destination = new File(javaDirectory, source.getName());
+              copy(source, destination);
             }
+          }
         }
     }
 
@@ -753,7 +752,7 @@ public class AppBundlerTask extends Task {
 
             // Write arguments
             writeStringArray(xout, "JVMArguments",arguments);
-
+            
             // Write arbitrary key-value pairs
             for (PlistEntry item : plistEntries) {
                 writeKey(xout, item.getKey());
@@ -841,42 +840,42 @@ public class AppBundlerTask extends Task {
         }
     }
 
-    public void writeBundleDocuments(XMLStreamWriter xout,
-            final ArrayList<BundleDocument> bundleDocuments) throws XMLStreamException {
+  public void writeBundleDocuments(XMLStreamWriter xout,
+                                   final ArrayList<BundleDocument> bundleDocuments) throws XMLStreamException {
 
-        xout.writeStartElement(ARRAY_TAG);
-        xout.writeCharacters("\n");
+    xout.writeStartElement(ARRAY_TAG);
+    xout.writeCharacters("\n");
 
-        for(BundleDocument bundleDocument: bundleDocuments) {
-            xout.writeStartElement(DICT_TAG);
-            xout.writeCharacters("\n");
+    for(BundleDocument bundleDocument: bundleDocuments) {
+      xout.writeStartElement(DICT_TAG);
+      xout.writeCharacters("\n");
 
-            final List<String> contentTypes = bundleDocument.getContentTypes();
-            if (contentTypes != null) {
-                writeStringArray(xout, "LSItemContentTypes", contentTypes);
-            } else {
-                writeStringArray(xout, "CFBundleTypeExtensions", bundleDocument.getExtensions());
-                writeProperty(xout, "LSTypeIsPackage", bundleDocument.isPackage());
-            }
-            writeStringArray(xout, "NSExportableTypes", bundleDocument.getExportableTypes());
+      final List<String> contentTypes = bundleDocument.getContentTypes();
+      if (contentTypes != null) {
+        writeStringArray(xout, "LSItemContentTypes", contentTypes);
+      } else {
+        writeStringArray(xout, "CFBundleTypeExtensions", bundleDocument.getExtensions());
+        writeProperty(xout, "LSTypeIsPackage", bundleDocument.isPackage());
+      }
+      writeStringArray(xout, "NSExportableTypes", bundleDocument.getExportableTypes());
 
-            final File ifile = bundleDocument.getIconFile();
-            writeProperty(xout, "CFBundleTypeIconFile", ifile != null ?
-                        ifile.getName() : bundleDocument.getIcon());
+      final File ifile = bundleDocument.getIconFile();
+      writeProperty(xout, "CFBundleTypeIconFile", ifile != null ?
+                                                  ifile.getName() : bundleDocument.getIcon());
 
-            writeProperty(xout, "CFBundleTypeName", bundleDocument.getName());
-            writeProperty(xout, "CFBundleTypeRole", bundleDocument.getRole());
-            writeProperty(xout, "LSHandlerRank", bundleDocument.getHandlerRank());
+      writeProperty(xout, "CFBundleTypeName", bundleDocument.getName());
+      writeProperty(xout, "CFBundleTypeRole", bundleDocument.getRole());
+      writeProperty(xout, "LSHandlerRank", bundleDocument.getHandlerRank());
 
-            xout.writeEndElement();
-            xout.writeCharacters("\n");
-        }
-
-        xout.writeEndElement();
-        xout.writeCharacters("\n");
+      xout.writeEndElement();
+      xout.writeCharacters("\n");
     }
 
-    public void writeTypeDeclarations(XMLStreamWriter xout,
+    xout.writeEndElement();
+    xout.writeCharacters("\n");
+  }
+  
+  public void writeTypeDeclarations(XMLStreamWriter xout,
             final ArrayList<TypeDeclaration> typeDeclarations) throws XMLStreamException {
         xout.writeStartElement(ARRAY_TAG);
         xout.writeCharacters("\n");

--- a/appbundler/src/com/oracle/appbundler/Option.java
+++ b/appbundler/src/com/oracle/appbundler/Option.java
@@ -33,22 +33,22 @@ package com.oracle.appbundler;
  * application.<p>
  * Assuming your {@code CFBundleIdentifier} (settable via {@link AppBundlerTask#setIdentifier(String)})
  * is {@code com.oracle.appbundler}. Then you can override a named option by calling
- * <xmp>
+ * <pre>
  *     import java.util.prefs.Preferences;
  *     [...]
  *     Preferences jvmOptions = Preferences.userRoot().node("/com/oracle/appbundler/JVMOptions");
  *     jvmOptions.put("name", "value");
  *     jvmOptions.flush();
- * </xmp>
+ * </pre>
  * The corresponding entries will be stored in a file called
  * {@code ~/Library/Preferences/com.oracle.appbundler.plist}.
  * To manipulate the file without Java's {@link java.util.prefs.Preferences} from the command line,
  * you should use the tool
  * <a href="https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/defaults.1.html">defaults</a>.
  * For example, to add an entry via the command line, use:
- * <xmp>
+ * <pre>
  *     defaults write com.oracle.appbundler /com/oracle/appbundler/ -dict-add JVMOptions/ '{"name"="value";}'
- * </xmp>
+ * </pre>
  *
  * @author <a href="mailto:hs@tagtraum.com">Hendrik Schreiber</a> (preference related code only)
  */

--- a/appbundler/src/com/oracle/appbundler/Runtime.java
+++ b/appbundler/src/com/oracle/appbundler/Runtime.java
@@ -73,6 +73,7 @@ public class Runtime extends FileSet {
         } else {
             appendIncludes(new String[] {
                     "lib/",
+                    "conf/",
                     "COPYRIGHT",
                     "LICENSE",
                     "README",


### PR DESCRIPTION
- Allow for max RAM limit to be specified as a percentage instead of a hardcoded value by appending a % to any options that start with -Xmx
- include the conf folder in bundled JRE, which is necessary for various settings including non-default security settings
- include tweaks used for maven support from https://github.com/evolvedbinary/appbundler-maven-build
