### PR TITLE
Fix res.zip unpacking

### DIFF
--- a/appbundler/src/com/oracle/appbundler/AppBundlerTask.java
+++ b/appbundler/src/com/oracle/appbundler/AppBundlerTask.java
@@ -487,8 +487,9 @@ public class AppBundlerTask extends Task {
                 File file = new File(resourcesDirectory, zipEntry.getName());
 
                 if (zipEntry.isDirectory()) {
-                    file.mkdir();
+                    file.mkdirs();
                 } else {
+                    file.getParentFile().mkdirs();
                     OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(file), BUFFER_SIZE);
 
                     try {


### PR DESCRIPTION
Don't assume that Directory entries come first in the res.zip file.