### PR TITLE
Fix launcher binary on OS X Mountain Lion (10.8)

### DIFF
--- a/appbundler/native/main.m
+++ b/appbundler/native/main.m
@@ -372,7 +372,7 @@ int launch(char *commandName, int progargc, char *progargv[]) {
     // Get the main class name
     NSString *mainClassName = [infoDictionary objectForKey:@JVM_MAIN_CLASS_NAME_KEY];
 
-    bool runningModule = [mainClassName containsString:@"/"];
+    bool runningModule = [mainClassName rangeOfString:@"/"].location != NSNotFound;
     
     if ( jnlplauncher != nil ) {
 


### PR DESCRIPTION
Java 8 can run on systems as old as OS X 10.8, but the launcher binary currently uses an API that was added in 10.10: [NSString containsString](https://developer.apple.com/documentation/foundation/nsstring/1414563-containsstring)

With this fix I have successfully launched an app on OS X 10.8 in a VM.

I tried to check for more possible API issues by building against the `MacOSX10.8.sdk` available [here](https://github.com/phracker/MacOSX-SDKs/releases) but encountered a bunch of issues I didn't understand, so I gave up. But in principle there could be other issues in code paths that my config does not exercise.