### PR TITLE
Replace symbol deprecated since macOS 10.12

### DIFF
--- a/appbundler/native/main.m
+++ b/appbundler/native/main.m
@@ -110,7 +110,7 @@ int main(int argc, char *argv[]) {
         result = 0;
     } @catch (NSException *exception) {
         NSAlert *alert = [[NSAlert alloc] init];
-        [alert setAlertStyle:NSCriticalAlertStyle];
+        [alert setAlertStyle:NSAlertStyleCritical];
         [alert setMessageText:[exception reason]];
         [alert runModal];
 


### PR DESCRIPTION
The symbol has been deprecated in favor of the enum since macOS Sierra (10.12). See [documentation](https://developer.apple.com/documentation/appkit/nscriticalalertstyle?language=objc) for details.