### PR TITLE
don't overwrite working directory with home directory

### DIFF
--- a/appbundler/native/main.m
+++ b/appbundler/native/main.m
@@ -165,7 +165,6 @@ int launch(char *commandName, int progargc, char *progargv[]) {
         workingDir = [workingDir stringByReplacingOccurrencesOfString:@APP_ROOT_PREFIX withString:[mainBundle bundlePath]];
     } else {
         workingDir = [[NSFileManager defaultManager] currentDirectoryPath];
-        workingDir = NSHomeDirectory(); // REVIEW: Check which if these ones is realy the users home directory ...
     }
     Log(@"Working Directory: '%@'", convertRelativeFilePath(workingDir));
 


### PR DESCRIPTION
When starting an application from the command line, it's important to have the current working directory properly set in order to access files passed with relative paths as arguments.

This was already once fixed in the past (see [here](https://github.com/TheInfiniteKind/appbundler/issues/14) and [here](https://bitbucket.org/infinitekind/appbundler/commits/4e4eb51ab31d)), but it looks like the bad behavior slipped in in a merge. Considering there is even a todo-like review request, I guessed it's save to just delete the line and revert to using the proper working directory.