### PR TITLE
Add support for a module path

### DIFF
--- a/appbundler/doc/appbundler.html
+++ b/appbundler/doc/appbundler.html
@@ -126,6 +126,13 @@ questions.
     <td align="center" valign="top">No</td>
   </tr>  
   <tr>
+    <td valign="top">plistModulePaths</td>
+    <td valign="top">A comma-separated list of modulepath-elements which are used for the java application.
+    <tt>$APP_ROOT</tt> is replaced by the path of the <tt>.app</tt>-bundle. Only applicable if <tt>mainclassname</tt>
+    references a modular class. By default uses all of the libraries added to the bundle using <tt>modulepath</tt>.</td>
+    <td align="center" valign="top">No</td>
+  </tr>  
+  <tr>
     <td valign="top">jvmRequired</td>
     <td valign="top">Specifies the required Java virtual machine version.</td>
     <td align="center" valign="top">No (defaults to <tt>1.7</tt>)</td>
@@ -212,6 +219,11 @@ bundle, and target systems must have a shared JRE installed in
 <p>A <a href="http://ant.apache.org/manual/Types/fileset.html">fileset</a> representing the class
 path of the bundled application. Corresponds to the <tt>java.class.path</tt> system property.
 Entries will be copied to the <tt>Contents/Java/</tt> folder of the generated bundle.</p>
+
+<h4>modulepath</h4>
+<p>A <a href="http://ant.apache.org/manual/Types/fileset.html">fileset</a> representing the module
+path of the bundled application. Entries will be copied to the <tt>Contents/Java/</tt> folder of
+the generated bundle, which will be added to the module path using <tt>--module-path</tt>.</p>
 
 <h4>librarypath</h4>
 <p>A <a href="http://ant.apache.org/manual/Types/fileset.html">fileset</a> representing the library

--- a/appbundler/native/main.m
+++ b/appbundler/native/main.m
@@ -40,6 +40,7 @@
 #define JVM_DEFAULT_OPTIONS_KEY "JVMDefaultOptions"
 #define JVM_ARGUMENTS_KEY "JVMArguments"
 #define JVM_CLASSPATH_KEY "JVMClassPath"
+#define JVM_MODULEPATH_KEY "JVMModulePath"
 #define JVM_VERSION_KEY "JVMVersion"
 #define JRE_PREFERRED_KEY "JREPreferred"
 #define JDK_PREFERRED_KEY "JDKPreferred"
@@ -320,6 +321,7 @@ int launch(char *commandName, int progargc, char *progargv[]) {
     NSString *javaPath = [mainBundlePath stringByAppendingString:@"/Contents/Java"];
     NSMutableArray *systemArguments = [[NSMutableArray alloc] init];
     NSMutableString *classPath = [NSMutableString stringWithString:@"-Djava.class.path="];
+    NSMutableString *modulePath = [NSMutableString stringWithFormat:@"--module-path="];
 
     // Set the library path
     NSString *libraryPath = [NSString stringWithFormat:@"-Djava.library.path=%@/Contents/MacOS", mainBundlePath];
@@ -477,10 +479,25 @@ int launch(char *commandName, int progargc, char *progargv[]) {
                 [classPath appendString:file];
             }
         }
+    } else {
+        NSArray *mp = [infoDictionary objectForKey:@JVM_MODULEPATH_KEY];
+        if (mp == nil) {
+            // Implicit module path, so use the contents of the "Java" folder to build an explicit module path
+            [modulePath appendFormat:@"%@", javaPath];
+        } else {
+            int k = 0;
+            for (NSString *file in mp) {
+                if (k++ > 0) [modulePath appendString:@":"]; // add separator if needed
+                file = [file stringByReplacingOccurrencesOfString:@APP_ROOT_PREFIX withString:[mainBundle bundlePath]];
+                [modulePath appendString:file];
+            }
+        }
     }
 
     if ( classPath != nil && !runningModule ) {
         [systemArguments addObject:classPath];
+    } else if (modulePath != nil && runningModule) {
+        [systemArguments addObject:modulePath];
     }
 
     // Set OSX special folders


### PR DESCRIPTION
I'm not ready to bundle all of my modules with the runtime as my project includes some dependencies which are not let modularised. This PR simply adds the `Contents/Java` directory to the module path, if the main class is modular, and supports the same sorts of configuration as the class path in order to make it customisable.