### PR TITLE
Don’t add LSArchitecturePriority key if there are no architectures

### DIFF
--- a/appbundler/src/com/oracle/appbundler/AppBundlerTask.java
+++ b/appbundler/src/com/oracle/appbundler/AppBundlerTask.java
@@ -741,7 +741,9 @@ public class AppBundlerTask extends Task {
             }
 
             // Write architectures
-            writeStringArray(xout, "LSArchitecturePriority", architectures, 2);
+            if (!architectures.isEmpty()) {
+                writeStringArray(xout, "LSArchitecturePriority", architectures, 2);
+            }
 
             // Write Environment
             writeKey(xout, "LSEnvironment", 2);


### PR DESCRIPTION
My app crashed on launch on M1 without Rosetta with the `LSArchitecturePriority` key in my `Info.plist` with `x86_64` first. Even with `arm64` second.

The error looked like:

```
The application cannot be opened for an unexpected reason, error=Error Domain=NSOSStatusErrorDomain Code=-10669 "(null)" UserInfo={_LSLine=4047, _LSFunction=_LSOpenStuffCallLocal}
```

Switching `arm64` to first place resolved the issue on M1, but that feels a bit weird. I noticed that very few other apps have the `LSArchitecturePriority` key in their `Info.plist`, so I tried removing `<arch.../>` from my AppBundler task configuration and everything works just fine.

However the `LSArchitecturePriority` key is still in my `Info.plist`, albeit an empty array, so this PR removes it if empty.

There is probably room to apply the same logic to other things like environment, and options, just to be tidy. I think that might make sense as part of this PR if you welcome this change. Let me know and I'll do it.