### PR TITLE
Workaround crash in JVM when argv is not NULL terminated

### DIFF
--- a/appbundler/native/main.m
+++ b/appbundler/native/main.m
@@ -629,7 +629,8 @@ int launch(char *commandName, int progargc, char *progargv[]) {
     if (runningModule)
         argc++;
 
-    char *argv[argc];
+    char *argv[argc + 1];
+    argv[argc] = NULL; /* Launch_JLI can crash if the argv array is not null-terminated: 9074879 */
 
     int i = 0;
     argv[i++] = commandName;


### PR DESCRIPTION
I'm curious around why others haven't seen this issue. There is a crash in the JVM when argv isn't NULL terminated, and it is not always NULL terminated in our code. I've reported a JDK bug for this separately... hopefully I'm not going crazy.